### PR TITLE
Support specifying item elements and scrollable container element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Support specifying item elements and scrollable container element, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/spyip/react-film/pull/XXX).
+- Support specifying item elements and scrollable container element, by [@compulim](https://github.com/compulim) in PR [#21](https://github.com/spyip/react-film/pull/21).
+
+### Changed
+- For performance reason, deep-customizing component will now need to pass `numItems` prop to `<Composer>`, by [@compulim](https://github.com/compulim) in PR [#21](https://github.com/spyip/react-film/pull/21).
 
 ## [1.2.0] - 2019-03-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support specifying item elements and scrollable container element, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/spyip/react-film/pull/XXX).
 
 ## [1.2.0] - 2019-03-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ import React from 'react';
 import { AutoCenter, Composer, Dots, FilmStrip, Flipper, ScrollBar } from 'react-film';
 
 export default ({ children }) =>
-  <Composer>
+  <Composer numItems={ React.Children.count(children) }>
     <div>
       <FilmStrip>
         { children }
@@ -206,6 +206,10 @@ export default ({ mode }) =>
     }
   </Context.Consumer>
 ```
+
+## Migrating from 1.x
+
+To reduce an extra render callback, we now require deep-customization users to pass in `numItems` prop to `<Composer>`.
 
 ## Context
 

--- a/README.md
+++ b/README.md
@@ -211,17 +211,19 @@ export default ({ mode }) =>
 
 Maybe you want to create a new flipper to control the carousel, the [context object](https://reactjs.org/docs/context.html) provides an API for interfacing with the carousel.
 
-| Name                  | Type                                                       | Description                                                                                       |
-|-----------------------|------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| `index`               | `number`                                                   | Index of the current item                                                                         |
-| `indexFraction`       | `number`                                                   | Index of the current item, in fraction (1.5 means 50% between 2nd and 3rd item)                   |
-| `numItems`            | `number`                                                   | Number of items in the carousel                                                                   |
-| `scrollBarPercentage` | `string`                                                   | Percentage of the scroll bar position                                                             |
-| `scrollBarWidth`      | `string`                                                   | Width (in percentage) of the scroll bar, respective to its total content                          |
-| `scrolling`           | `boolean`                                                  | `true` if the user is scrolling (debounced 500ms after last `onScroll` event), otherwise, `false` |
-| `scrollOneLeft`       | `() => {}`                                                 | Helper function to scroll one item to the left                                                    |
-| `scrollOneRight`      | `() => {}`                                                 | Helper function to scroll one item to the right                                                   |
-| `scrollTo`            | `(({ index: number, indexFraction: number }) => {}) => {}` | Scroll to a specified index, see [sample below](#sample-scrollto-code)                            |
+| Name                  | Type                                                         | Description                                                                                       |
+|-----------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `index`               | `number`                                                     | Index of the current item                                                                         |
+| `indexFraction`       | `number`                                                     | Index of the current item, in fraction (1.5 means 50% between 2nd and 3rd item)                   |
+| `itemContainerRef`    | [React refs](https://reactjs.org/docs/refs-and-the-dom.html) | Ref of the immediate parent element containing all scrollable items                               |
+| `numItems`            | `number`                                                     | Number of items in the carousel                                                                   |
+| `scrollableRef`       | [React refs](https://reactjs.org/docs/refs-and-the-dom.html) | Ref of the scrollable element, use for artificial scrolling and tracking scroll position          |
+| `scrollBarPercentage` | `string`                                                     | Percentage of the scroll bar position                                                             |
+| `scrollBarWidth`      | `string`                                                     | Width (in percentage) of the scroll bar, respective to its total content                          |
+| `scrolling`           | `boolean`                                                    | `true` if the user is scrolling (debounced 500ms after last `onScroll` event), otherwise, `false` |
+| `scrollOneLeft`       | `() => {}`                                                   | Helper function to scroll one item to the left                                                    |
+| `scrollOneRight`      | `() => {}`                                                   | Helper function to scroll one item to the right                                                   |
+| `scrollTo`            | `(({ index: number, indexFraction: number }) => {}) => {}`   | Scroll to a specified index, see [sample below](#sample-scrollto-code)                            |
 
 > If the context object lack of features you want to use, just [tell us your idea](https://github.com/spyip/react-film/issues).
 

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -5116,6 +5116,11 @@
 				"mimic-fn": "^1.0.0"
 			}
 		},
+		"memoize-one": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+			"integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
+		},
 		"merge": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -46,7 +46,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "glamor": "^2.20.40"
+    "glamor": "^2.20.40",
+    "memoize-one": "^5.0.4"
   },
   "peerDependencies": {
     "react": "^16.4.1"

--- a/packages/component/src/BasicFilm.js
+++ b/packages/component/src/BasicFilm.js
@@ -12,17 +12,28 @@ import Flipper from './Flipper';
 import memoize from './memoize';
 import ScrollBar from './ScrollBar';
 
+import InternalContext from './InternalContext';
+
 const CAROUSEL_CSS = css({
   overflow: 'hidden',
   position: 'relative'
 });
 
-export default class BasicFilm extends React.Component {
+class BasicFilm extends React.Component {
   constructor(props) {
     super(props);
 
     this.createHeightStyle = memoize(height => ({ height }));
     this.createBasicStyleSet = memoize(({ autoHide }) => createBasicStyleSet({ autoHide }));
+
+    this.props.setNumItems(React.Children.count(this.props.children));
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const numItems = React.Children.count(this.props.children);
+    const nextNumItems = React.Children.count(nextProps.children);
+
+    numItems !== nextNumItems && nextProps.setNumItems(nextNumItems);
   }
 
   render() {
@@ -43,55 +54,73 @@ export default class BasicFilm extends React.Component {
 
     const {
       leftFlipperText = '<',
+      numItems,
       rightFlipperText = '>',
+      scrollBarWidth,
+      scrolling,
       showDots = true,
       showFlipper = true,
       showScrollBar = true
     } = props;
 
     return (
-      <Composer>
-        <Context.Consumer>
-          { ({ numItems, scrollBarWidth, scrolling }) =>
-            <div className={ props.className }>
-              <div
-                className={ classNames(CAROUSEL_CSS + '', { scrolling }, carousel + '') }
-                style={ this.createHeightStyle(props.height) }
+      <React.Fragment>
+        <div className={ props.className }>
+          <div
+            className={ classNames(CAROUSEL_CSS + '', { scrolling }, carousel + '') }
+            style={ this.createHeightStyle(props.height) }
+          >
+            { !!numItems && scrollBarWidth !== '100%' && !!showFlipper &&
+              <Flipper className={ leftFlipper + '' } mode="left">
+                <div>{ leftFlipperText }</div>
+              </Flipper>
+            }
+            <FilmStrip>
+              { props.children }
+            </FilmStrip>
+            { !!numItems && scrollBarWidth !== '100%' && !!showFlipper &&
+              <Flipper className={ rightFlipper + '' } mode="right">
+                <div>{ rightFlipperText }</div>
+              </Flipper>
+            }
+            { !!numItems && scrollBarWidth !== '100%' && !!showScrollBar &&
+              <ScrollBar
+                className={ scrollBarBox + '' }
+                handlerClassName={ scrollBarHandler + '' }
+              />
+            }
+          </div>
+          {
+            !!numItems && scrollBarWidth !== '100%' && !!showDots &&
+              <Dots
+                className={ dotsBox + '' }
+                itemClassName={ dotsItem + ''}
               >
-                { !!numItems && scrollBarWidth !== '100%' && !!showFlipper &&
-                  <Flipper className={ leftFlipper + '' } mode="left">
-                    <div>{ leftFlipperText }</div>
-                  </Flipper>
-                }
-                <FilmStrip>
-                  { props.children }
-                </FilmStrip>
-                { !!numItems && scrollBarWidth !== '100%' && !!showFlipper &&
-                  <Flipper className={ rightFlipper + '' } mode="right">
-                    <div>{ rightFlipperText }</div>
-                  </Flipper>
-                }
-                { !!numItems && scrollBarWidth !== '100%' && !!showScrollBar &&
-                  <ScrollBar
-                    className={ scrollBarBox + '' }
-                    handlerClassName={ scrollBarHandler + '' }
-                  />
-                }
-              </div>
-              {
-                !!numItems && scrollBarWidth !== '100%' && !!showDots &&
-                  <Dots
-                    className={ dotsBox + '' }
-                    itemClassName={ dotsItem + ''}
-                  >
-                    { () => <div /> }
-                  </Dots>
-              }
-            </div>
+                { () => <div /> }
+              </Dots>
           }
-        </Context.Consumer>
+        </div>
         { props.autoCenter !== false && <AutoCenter /> }
-      </Composer>
+      </React.Fragment>
     );
   }
 }
+
+export default props =>
+  <Composer>
+    <InternalContext.Consumer>
+      { ({ setNumItems }) =>
+        <Context.Consumer>
+          { ({ numItems, scrollBarWidth, scrolling }) =>
+            <BasicFilm
+              { ...props }
+              numItems={ numItems }
+              scrollBarWidth={ scrollBarWidth }
+              scrolling={ scrolling }
+              setNumItems={ setNumItems }
+            />
+          }
+        </Context.Consumer>
+      }
+    </InternalContext.Consumer>
+  </Composer>

--- a/packages/component/src/BasicFilm.js
+++ b/packages/component/src/BasicFilm.js
@@ -12,8 +12,6 @@ import Flipper from './Flipper';
 import memoize from './memoize';
 import ScrollBar from './ScrollBar';
 
-import InternalContext from './InternalContext';
-
 const CAROUSEL_CSS = css({
   overflow: 'hidden',
   position: 'relative'
@@ -25,15 +23,6 @@ class BasicFilm extends React.Component {
 
     this.createHeightStyle = memoize(height => ({ height }));
     this.createBasicStyleSet = memoize(({ autoHide }) => createBasicStyleSet({ autoHide }));
-
-    this.props.setNumItems(React.Children.count(this.props.children));
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const numItems = React.Children.count(this.props.children);
-    const nextNumItems = React.Children.count(nextProps.children);
-
-    numItems !== nextNumItems && nextProps.setNumItems(nextNumItems);
   }
 
   render() {
@@ -107,20 +96,15 @@ class BasicFilm extends React.Component {
 }
 
 export default props =>
-  <Composer>
-    <InternalContext.Consumer>
-      { ({ setNumItems }) =>
-        <Context.Consumer>
-          { ({ numItems, scrollBarWidth, scrolling }) =>
-            <BasicFilm
-              { ...props }
-              numItems={ numItems }
-              scrollBarWidth={ scrollBarWidth }
-              scrolling={ scrolling }
-              setNumItems={ setNumItems }
-            />
-          }
-        </Context.Consumer>
+  <Composer numItems={ React.Children.count(props.children) }>
+    <Context.Consumer>
+      { ({ numItems, scrollBarWidth, scrolling }) =>
+        <BasicFilm
+          { ...props }
+          numItems={ numItems }
+          scrollBarWidth={ scrollBarWidth }
+          scrolling={ scrolling }
+        />
       }
-    </InternalContext.Consumer>
+    </Context.Consumer>
   </Composer>

--- a/packages/component/src/BasicFilm.js
+++ b/packages/component/src/BasicFilm.js
@@ -23,10 +23,17 @@ export default class BasicFilm extends React.Component {
 
     this.createHeightStyle = memoize(height => ({ height }));
     this.createBasicStyleSet = memoize(({ autoHide }) => createBasicStyleSet({ autoHide }));
+
+    this.itemContainerRef = React.createRef();
+    this.scrollableRef = React.createRef();
   }
 
   render() {
-    const { props } = this;
+    const {
+      itemContainerRef,
+      props,
+      scrollableRef
+    } = this;
 
     const {
       carousel,
@@ -50,7 +57,10 @@ export default class BasicFilm extends React.Component {
     } = props;
 
     return (
-      <Composer>
+      <Composer
+        itemContainerRef={ itemContainerRef }
+        scrollableRef={ scrollableRef }
+      >
         <Context.Consumer>
           { ({ numItems, scrollBarWidth, scrolling }) =>
             <div className={ props.className }>
@@ -63,7 +73,10 @@ export default class BasicFilm extends React.Component {
                     <div>{ leftFlipperText }</div>
                   </Flipper>
                 }
-                <FilmStrip>
+                <FilmStrip
+                  itemContainerRef={ itemContainerRef }
+                  scrollableRef={ scrollableRef }
+                >
                   { props.children }
                 </FilmStrip>
                 { !!numItems && scrollBarWidth !== '100%' && !!showFlipper &&

--- a/packages/component/src/BasicFilm.js
+++ b/packages/component/src/BasicFilm.js
@@ -23,17 +23,10 @@ export default class BasicFilm extends React.Component {
 
     this.createHeightStyle = memoize(height => ({ height }));
     this.createBasicStyleSet = memoize(({ autoHide }) => createBasicStyleSet({ autoHide }));
-
-    this.itemContainerRef = React.createRef();
-    this.scrollableRef = React.createRef();
   }
 
   render() {
-    const {
-      itemContainerRef,
-      props,
-      scrollableRef
-    } = this;
+    const { props } = this;
 
     const {
       carousel,
@@ -57,10 +50,7 @@ export default class BasicFilm extends React.Component {
     } = props;
 
     return (
-      <Composer
-        itemContainerRef={ itemContainerRef }
-        scrollableRef={ scrollableRef }
-      >
+      <Composer>
         <Context.Consumer>
           { ({ numItems, scrollBarWidth, scrolling }) =>
             <div className={ props.className }>
@@ -73,10 +63,7 @@ export default class BasicFilm extends React.Component {
                     <div>{ leftFlipperText }</div>
                   </Flipper>
                 }
-                <FilmStrip
-                  itemContainerRef={ itemContainerRef }
-                  scrollableRef={ scrollableRef }
-                >
+                <FilmStrip>
                   { props.children }
                 </FilmStrip>
                 { !!numItems && scrollBarWidth !== '100%' && !!showFlipper &&

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -115,8 +115,8 @@ export default class FilmComposer extends React.Component {
         }
       },
       internalContext: {
-        _setNumItems: numItems => {
-          this.setState(({ context }) => ({
+        setNumItems: numItems => {
+          this.state.context.numItems !== numItems && this.setState(({ context }) => ({
             context: {
               ...context,
               numItems

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -6,12 +6,16 @@ import InternalContext from './InternalContext';
 import ScrollSpy from './ScrollSpy';
 import ScrollTo from './ScrollTo';
 
-function getView(current, scrollingTo) {
-  if (current) {
-    const scrollLeft = scrollingTo || current.scrollLeft;
-    const items = current.children[0].children; // This will enumerate <li> inside <FilmStrip>
-    const scrollCenter = scrollLeft + current.offsetWidth / 2;
-    const index = best([].slice.call(items), item => {
+function getView(
+  { current: scrollable } = {},
+  { current: itemContainer } = {},
+  scrollingTo
+) {
+  if (itemContainer && scrollable) {
+    const scrollLeft = scrollingTo || scrollable.scrollLeft;
+    const items = itemContainer.children; // This will enumerate <li> inside <FilmStrip>
+    const scrollCenter = scrollLeft + scrollable.offsetWidth / 2;
+    const index = best([...items], item => {
       const offsetCenter = item.offsetLeft + item.offsetWidth / 2;
 
       return 1 / Math.abs(scrollCenter - offsetCenter);
@@ -23,10 +27,10 @@ function getView(current, scrollingTo) {
       let indexFraction = index + (scrollCenter - offsetCenter) / item.offsetWidth;
 
       // We "fix" indexFraction if the viewport is at the start/end of the content
-      // This is to simplify code that use Math.round(indexFraction) to find the current index
+      // This is to simplify code that use Math.round(indexFraction) to find the scrollable index
       // if (scrollLeft === 0) {
       //   indexFraction = 0;
-      // } else if (scrollLeft >= current.scrollWidth - current.offsetWidth) {
+      // } else if (scrollLeft >= scrollable.scrollWidth - scrollable.offsetWidth) {
       //   indexFraction = items.length - 1;
       // } else if (indexFraction % 1 > .99 || indexFraction % 1 < .01) {
       //   indexFraction = Math.round(indexFraction);
@@ -40,7 +44,7 @@ function getView(current, scrollingTo) {
 
       if (scrollLeft === 0) {
         selectedIndex = 0;
-      } else if (scrollLeft >= current.scrollWidth - current.offsetWidth) {
+      } else if (scrollLeft >= scrollable.scrollWidth - scrollable.offsetWidth) {
         selectedIndex = items.length - 1;
       } else {
         selectedIndex = Math.round(indexFraction);
@@ -48,23 +52,25 @@ function getView(current, scrollingTo) {
 
       return {
         index: selectedIndex,
-        indexFraction,
-        items,
-        current
+        indexFraction
       };
     }
   }
 }
 
-function getScrollLeft(current, index) {
-  if (current) {
-    const items = current.children[0].children; // This will enumerate <li> inside <FilmStrip>
+function getScrollLeft(
+  { current: scrollable } = {},
+  { current: itemContainer } = {},
+  index
+) {
+  if (itemContainer && scrollable) {
+    const items = itemContainer.children; // This will enumerate <li> inside <FilmStrip>
     const item = items[Math.max(0, Math.min(items.length - 1, index))];
 
     if (item) {
       const itemOffsetCenter = item.offsetLeft + item.offsetWidth / 2;
 
-      return itemOffsetCenter - current.offsetWidth / 2;
+      return itemOffsetCenter - scrollable.offsetWidth / 2;
     }
   }
 }
@@ -76,8 +82,11 @@ export default class FilmComposer extends React.Component {
     this.handleScroll = this.handleScroll.bind(this);
     this.handleScrollToEnd = this.handleScrollToEnd.bind(this);
 
+    // TODO: How about Composer prepare createRef()?
+
     this.state = {
-      filmStrip: null,
+      itemContainerRef: props.itemContainerRef,
+      scrollableRef: props.scrollableRef,
       scrollLeft: null,
       context: {
         numItems: 0,
@@ -86,14 +95,14 @@ export default class FilmComposer extends React.Component {
         scrolling: false,
         scrollTo: scrollTo => {
           this.setState(state => {
-            const view = getView(state.filmStrip, state.scrollLeft);
+            const view = getView(state.scrollableRef, state.itemContainerRef, state.scrollLeft);
 
             if (view) {
               const { index, indexFraction } = view;
               const targetIndex = scrollTo({ index, indexFraction });
 
               if (typeof targetIndex === 'number') {
-                return { scrollLeft: getScrollLeft(state.filmStrip, targetIndex) };
+                return { scrollLeft: getScrollLeft(state.scrollableRef, state.itemContainerRef, targetIndex) };
               }
             }
           });
@@ -106,7 +115,6 @@ export default class FilmComposer extends React.Component {
         }
       },
       internalContext: {
-        _setFilmStripRef: filmStrip => this.setState(() => ({ filmStrip })),
         _setNumItems: numItems => {
           this.setState(({ context }) => ({
             context: {
@@ -114,9 +122,21 @@ export default class FilmComposer extends React.Component {
               numItems
             }
           }));
-        },
+        }
       }
     };
+  }
+
+  componentWillReceiveProps({ itemContainerRef, scrollableRef }) {
+    if (
+      itemContainerRef !== this.props.itemContainerRef
+      || scrollableRef !== this.props.scrollableRef
+    ) {
+      this.setState(() => ({
+        itemContainerRef,
+        scrollableRef
+      }));
+    }
   }
 
   componentWillUnmount() {
@@ -124,8 +144,8 @@ export default class FilmComposer extends React.Component {
   }
 
   handleScroll({ fraction: scrollBarPercentage, initial, width: scrollBarWidth }) {
-    this.setState(({ context, filmStrip, scrollLeft }) => {
-      const view = getView(filmStrip, scrollLeft);
+    this.setState(({ context, itemContainerRef, scrollableRef, scrollLeft }) => {
+      const view = getView(scrollableRef, itemContainerRef, scrollLeft);
 
       if (view) {
         const { index, indexFraction } = view;
@@ -168,20 +188,20 @@ export default class FilmComposer extends React.Component {
         <Context.Provider value={ state.context }>
           { this.props.children }
           {
-            !!state.filmStrip &&
+            !!state.scrollableRef &&
               <ScrollSpy
                 onScroll={ this.handleScroll }
-                target={ state.filmStrip }
+                targetRef={ state.scrollableRef }
               />
           }
           {
             typeof state.scrollLeft === 'number'
-            && !!state.filmStrip
+            && !!state.scrollableRef
             &&
               <ScrollTo
                 onEnd={ this.handleScrollToEnd }
                 scrollLeft={ state.scrollLeft }
-                target={ state.filmStrip }
+                targetRef={ state.scrollableRef }
               />
           }
         </Context.Provider>

--- a/packages/component/src/FilmStrip.js
+++ b/packages/component/src/FilmStrip.js
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 import CallFunction from './CallFunction';
+import Context from './Context';
 import InternalContext from './InternalContext';
 
 const ROOT_CSS = css({
@@ -26,25 +27,27 @@ const ROOT_CSS = css({
 
 export default ({
   children,
-  className,
-  itemContainerRef,
-  scrollableRef
+  className
 }) =>
   <InternalContext.Consumer>
     { ({ _setNumItems }) =>
-      <React.Fragment>
-        <div
-          className={ classNames(ROOT_CSS + '', className) }
-          ref={ scrollableRef }
-        >
-          <ul ref={ itemContainerRef }>
-            { React.Children.map(children, child => <li>{ child }</li>) }
-          </ul>
-        </div>
-        <CallFunction
-          arg={ React.Children.count(children) }
-          fn={ _setNumItems }
-        />
-      </React.Fragment>
+      <Context.Consumer>
+        { ({ itemContainerRef, scrollableRef }) =>
+          <React.Fragment>
+            <div
+              className={ classNames(ROOT_CSS + '', className) }
+              ref={ scrollableRef }
+            >
+              <ul ref={ itemContainerRef }>
+                { React.Children.map(children, child => <li>{ child }</li>) }
+              </ul>
+            </div>
+            <CallFunction
+              arg={ React.Children.count(children) }
+              fn={ _setNumItems }
+            />
+          </React.Fragment>
+        }
+      </Context.Consumer>
     }
   </InternalContext.Consumer>

--- a/packages/component/src/FilmStrip.js
+++ b/packages/component/src/FilmStrip.js
@@ -24,20 +24,25 @@ const ROOT_CSS = css({
   }
 });
 
-export default props =>
+export default ({
+  children,
+  className,
+  itemContainerRef,
+  scrollableRef
+}) =>
   <InternalContext.Consumer>
-    { ({ _setFilmStripRef, _setNumItems }) =>
+    { ({ _setNumItems }) =>
       <React.Fragment>
         <div
-          className={ classNames(ROOT_CSS + '', props.className) }
-          ref={ _setFilmStripRef }
+          className={ classNames(ROOT_CSS + '', className) }
+          ref={ scrollableRef }
         >
-          <ul>
-            { React.Children.map(props.children, child => <li>{ child }</li>) }
+          <ul ref={ itemContainerRef }>
+            { React.Children.map(children, child => <li>{ child }</li>) }
           </ul>
         </div>
         <CallFunction
-          arg={ React.Children.count(props.children) }
+          arg={ React.Children.count(children) }
           fn={ _setNumItems }
         />
       </React.Fragment>

--- a/packages/component/src/FilmStrip.js
+++ b/packages/component/src/FilmStrip.js
@@ -2,9 +2,7 @@ import { css } from 'glamor';
 import classNames from 'classnames';
 import React from 'react';
 
-import CallFunction from './CallFunction';
 import Context from './Context';
-import InternalContext from './InternalContext';
 
 const ROOT_CSS = css({
   MsOverflowStyle: 'none',
@@ -29,25 +27,15 @@ export default ({
   children,
   className
 }) =>
-  <InternalContext.Consumer>
-    { ({ _setNumItems }) =>
-      <Context.Consumer>
-        { ({ itemContainerRef, scrollableRef }) =>
-          <React.Fragment>
-            <div
-              className={ classNames(ROOT_CSS + '', className) }
-              ref={ scrollableRef }
-            >
-              <ul ref={ itemContainerRef }>
-                { React.Children.map(children, child => <li>{ child }</li>) }
-              </ul>
-            </div>
-            <CallFunction
-              arg={ React.Children.count(children) }
-              fn={ _setNumItems }
-            />
-          </React.Fragment>
-        }
-      </Context.Consumer>
+  <Context.Consumer>
+    { ({ itemContainerRef, scrollableRef }) =>
+      <div
+        className={ classNames(ROOT_CSS + '', className) }
+        ref={ scrollableRef }
+      >
+        <ul ref={ itemContainerRef }>
+          { React.Children.map(children, child => <li>{ child }</li>) }
+        </ul>
+      </div>
     }
-  </InternalContext.Consumer>
+  </Context.Consumer>

--- a/packages/component/src/InternalContext.js
+++ b/packages/component/src/InternalContext.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default React.createContext({
-  setNumItems: () => 0
-});

--- a/packages/component/src/InternalContext.js
+++ b/packages/component/src/InternalContext.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
 export default React.createContext({
-  _setFilmStripRef: () => 0,
   _setNumItems: () => 0
 });

--- a/packages/component/src/InternalContext.js
+++ b/packages/component/src/InternalContext.js
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export default React.createContext({
-  _setNumItems: () => 0
+  setNumItems: () => 0
 });

--- a/packages/component/src/ScrollSpy.js
+++ b/packages/component/src/ScrollSpy.js
@@ -16,46 +16,46 @@ export default class ScrollSpy extends React.Component {
   }
 
   componentDidMount() {
-    const { target } = this.props;
+    const { targetRef: { current } = {} } = this.props;
 
-    if (target) {
-      target.addEventListener('pointerover', this.handlePointerOver, { passive: true });
-      target.addEventListener('scroll', this.handleScroll, { passive: true });
-      this.emitInitialScrollEvent(target);
+    if (current) {
+      current.addEventListener('pointerover', this.handlePointerOver, { passive: true });
+      current.addEventListener('scroll', this.handleScroll, { passive: true });
+      this.emitInitialScrollEvent(current);
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.target !== this.props.target) {
-      const { target: prevTarget } = prevProps;
-      const { target } = this.props;
+    if (prevProps.targetRef !== this.props.targetRef) {
+      const { targetRef: { current: prevCurrent } = {} } = prevProps;
+      const { targetRef: { current } = {} } = this.props;
 
-      if (prevTarget) {
-        prevTarget.removeEventListener('pointerover', this.handlePointerOver);
-        prevTarget.removeEventListener('scroll', this.handleScroll);
+      if (prevCurrent) {
+        prevCurrent.removeEventListener('pointerover', this.handlePointerOver);
+        prevCurrent.removeEventListener('scroll', this.handleScroll);
       }
 
-      if (target) {
-        target.addEventListener('pointerover', this.handlePointerOver, { passive: true });
-        target.addEventListener('scroll', this.handleScroll, { passive: true });
-        this.emitInitialScrollEvent(target);
+      if (current) {
+        current.addEventListener('pointerover', this.handlePointerOver, { passive: true });
+        current.addEventListener('scroll', this.handleScroll, { passive: true });
+        this.emitInitialScrollEvent(current);
       }
     }
   }
 
-  emitInitialScrollEvent(target, waited) {
-    if (!waited && target.scrollWidth === target.offsetWidth) {
+  emitInitialScrollEvent(current, waited) {
+    if (!waited && current.scrollWidth === current.offsetWidth) {
       // HACK: Chrome 66 will initially say scrollWidth equals to offsetWidth, until some time later
-      setTimeout(() => this.emitInitialScrollEvent(target, true));
+      setTimeout(() => this.emitInitialScrollEvent(current, true));
     }
 
-    this.handleScroll({ target }, true);
+    this.handleScroll({ target: current }, true);
   }
 
   componentWillUnmount() {
-    const { target } = this.props;
+    const { targetRef: { current } = {} } = this.props;
 
-    target && target.removeEventListener('scroll', this.handleScroll);
+    current && current.removeEventListener('scroll', this.handleScroll);
   }
 
   handlePointerOver() {
@@ -63,9 +63,9 @@ export default class ScrollSpy extends React.Component {
     // For example, the container resized, the scroll width will be incorrect
     // We will debounce to prevent "pointerOver" calculating too often
     // We will memoize to prevent firing unnecessary "onScroll"
-    const { target } = this.props;
+    const { targetRef: { current } = {} } = this.props;
 
-    this.handleScroll({ target });
+    this.handleScroll({ target: current });
   }
 
   handleScroll({ target }, initial = false) {

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -11,34 +11,103 @@ const LIST_FILM_ITEM_CSS = css({
   width: 200
 });
 
+const FRAME_CSS = css({
+  lineHeight: 0,
+  position: 'relative',
+
+  '& > button': {
+    position: 'absolute',
+    right: 10,
+    top: 10
+  }
+});
+
 const styleSet = createBasicStyleSet({ autoHide: false });
 const myStyleSet = {
   ...styleSet,
   scrollBarHandler: styleSet.scrollBarHandler + ' ' + css({ backgroundColor: 'Red' })
 };
 
+function pad(value, count = 2, padding = '0') {
+  value += '';
+  count -= value.length;
+
+  while (--count >= 0) {
+    value = padding + value;
+  }
+
+  return value;
+}
+
 function randomID() {
   return Math.random().toString(36).substr(2, 5);
+}
+
+function wrap(value, from, to) {
+  const width = to - from + 1;
+
+  while (value < from) {
+    value += width;
+  }
+
+  while (value > to) {
+    value -= width;
+  }
+
+  return value;
 }
 
 export default class extends React.Component {
   constructor(props) {
     super(props);
 
+    this.handleAppendItem = this.handleAppendItem.bind(this);
+    this.handlePrependItem = this.handlePrependItem.bind(this);
     this.handleRandomKeyClick = this.handleRandomKeyClick.bind(this);
+    this.handleRemoveItemAt = this.handleRemoveItemAt.bind(this);
 
     this.state = {
+      items: ['01', '02', '03'],
       key: randomID()
     };
+  }
+
+  handleAppendItem() {
+    this.setState(({ items }) => {
+      return {
+        items: [...items, pad(wrap((+items[items.length - 1] || 0) + 1, 1, 11))]
+      };
+    });
+  }
+
+  handlePrependItem() {
+    this.setState(({ items }) => {
+      return {
+        items: [pad(wrap((+items[0] || 0) - 1, 1, 11)), ...items]
+      };
+    });
   }
 
   handleRandomKeyClick() {
     this.setState(() => ({ key: randomID() }));
   }
 
+  handleRemoveItemAt(index) {
+    this.setState(({ items }) => {
+      const nextItems = [...items];
+
+      nextItems.splice(index, 1);
+
+      return {
+        ...items,
+        items: nextItems
+      };
+    });
+  }
+
   render() {
     const {
-      state: { key }
+      state: { items, key }
     } = this;
 
     return (
@@ -171,6 +240,18 @@ export default class extends React.Component {
             </ul>
           </BasicFilm>
         }
+        <BasicFilm>
+          { items.map((item, index) =>
+            <div className={ FRAME_CSS } key={ index }>
+              <img alt={ `Cat ${ item }` } src={ `image/${ item }.jpg` } />
+              <button onClick={ this.handleRemoveItemAt.bind(null, index) }>&times;</button>
+            </div>
+          ) }
+        </BasicFilm>
+        <div>
+          <button onClick={ this.handleAppendItem }>Append a cat</button>
+          <button onClick={ this.handlePrependItem }>Prepend a cat</button>
+        </div>
         <p>Deserunt mollit elit laborum quis commodo magna. Nulla ad amet pariatur exercitation sint dolore. Mollit in in duis deserunt dolore anim. Qui fugiat in sit ut do voluptate ipsum nostrud. Ad culpa officia sunt enim. Adipisicing ut dolore commodo fugiat. Do Lorem occaecat nisi nulla fugiat consectetur exercitation est sit et laborum.</p>
         <p>Sunt nostrud amet commodo consectetur culpa incididunt voluptate. Mollit tempor tempor nostrud ad non excepteur reprehenderit ea. Cillum mollit reprehenderit mollit minim eiusmod deserunt reprehenderit. Sit cupidatat laborum dolore et magna duis Lorem aute sint fugiat sunt sunt. Sit non nostrud aliquip et nisi ad ullamco aute proident enim sit sit consectetur velit. Enim excepteur voluptate culpa anim laborum commodo eu excepteur.</p>
         <p>Mollit fugiat proident consectetur excepteur mollit. Commodo ipsum laboris dolor voluptate amet eu amet excepteur quis incididunt quis veniam. Laborum anim ex nisi consectetur commodo adipisicing elit minim cillum fugiat. Id non amet adipisicing non ipsum pariatur. Ad mollit ea culpa enim nostrud exercitation occaecat velit aute esse. Reprehenderit sint et duis veniam excepteur duis irure aliquip amet. Deserunt ullamco incididunt Lorem excepteur est ea ipsum.</p>

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -221,8 +221,8 @@ export default class extends React.Component {
           ) }
         </BasicFilm>
         <div>
-          <button onClick={ this.handleAppendItem }>Append a cat</button>
-          <button onClick={ this.handlePrependItem }>Prepend a cat</button>
+          <button onClick={ this.handlePrependItem }>Insert a cat to the left</button>
+          <button onClick={ this.handleAppendItem }>Insert a cat to the right</button>
         </div>
         <p>Deserunt mollit elit laborum quis commodo magna. Nulla ad amet pariatur exercitation sint dolore. Mollit in in duis deserunt dolore anim. Qui fugiat in sit ut do voluptate ipsum nostrud. Ad culpa officia sunt enim. Adipisicing ut dolore commodo fugiat. Do Lorem occaecat nisi nulla fugiat consectetur exercitation est sit et laborum.</p>
         <p>Sunt nostrud amet commodo consectetur culpa incididunt voluptate. Mollit tempor tempor nostrud ad non excepteur reprehenderit ea. Cillum mollit reprehenderit mollit minim eiusmod deserunt reprehenderit. Sit cupidatat laborum dolore et magna duis Lorem aute sint fugiat sunt sunt. Sit non nostrud aliquip et nisi ad ullamco aute proident enim sit sit consectetur velit. Enim excepteur voluptate culpa anim laborum commodo eu excepteur.</p>

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -11,17 +11,6 @@ const LIST_FILM_ITEM_CSS = css({
   width: 200
 });
 
-const FRAME_CSS = css({
-  lineHeight: 0,
-  position: 'relative',
-
-  '& > button': {
-    position: 'absolute',
-    right: 10,
-    top: 10
-  }
-});
-
 const styleSet = createBasicStyleSet({ autoHide: false });
 const myStyleSet = {
   ...styleSet,
@@ -64,7 +53,6 @@ export default class extends React.Component {
     this.handleAppendItem = this.handleAppendItem.bind(this);
     this.handlePrependItem = this.handlePrependItem.bind(this);
     this.handleRandomKeyClick = this.handleRandomKeyClick.bind(this);
-    this.handleRemoveItemAt = this.handleRemoveItemAt.bind(this);
 
     this.state = {
       items: ['01', '02', '03'],
@@ -90,19 +78,6 @@ export default class extends React.Component {
 
   handleRandomKeyClick() {
     this.setState(() => ({ key: randomID() }));
-  }
-
-  handleRemoveItemAt(index) {
-    this.setState(({ items }) => {
-      const nextItems = [...items];
-
-      nextItems.splice(index, 1);
-
-      return {
-        ...items,
-        items: nextItems
-      };
-    });
   }
 
   render() {
@@ -241,11 +216,8 @@ export default class extends React.Component {
           </BasicFilm>
         }
         <BasicFilm>
-          { items.map((item, index) =>
-            <div className={ FRAME_CSS } key={ index }>
-              <img alt={ `Cat ${ item }` } src={ `image/${ item }.jpg` } />
-              <button onClick={ this.handleRemoveItemAt.bind(null, index) }>&times;</button>
-            </div>
+          { items.map(item =>
+            <img alt={ `Cat ${ item }` } src={ `image/${ item }.jpg` } />
           ) }
         </BasicFilm>
         <div>


### PR DESCRIPTION
## Background

This PR is to support complex scrolling scenario:

- Allowing some elements in the carousel DOM tree not counting towards one of the scrolling item
   - For example, adding a header element with variable height to the scroll view, and flippers/dots should ignore the header element

## CHANGELOG

### Added
- Support specifying item elements and scrollable container element, by [@compulim](https://github.com/compulim) in PR [#21](https://github.com/spyip/react-film/pull/21).

### Changed
- For performance reason, deep-customizing component will now need to pass `numItems` prop to `<Composer>`, by [@compulim](https://github.com/compulim) in PR [#21](https://github.com/spyip/react-film/pull/21).
