### PR TITLE
Replace `[...elements]` with `[].slice.call(elements)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - For performance reason, deep-customizing component will now need to pass `numItems` prop to `<Composer>`, by [@compulim](https://github.com/compulim) in PR [#21](https://github.com/spyip/react-film/pull/21).
 
+### Fixed
+- Fix [#23](https://github.com/spyip/react-film/issues/23). Fix IE11 not working with CoreJS-polyfilled `[...document.children]`, by [@compulim](https://github.com/compulim) in PR [#24](https://github.com/spyip/react-film/pull/24).
+
 ## [1.2.0] - 2019-03-20
 ### Added
 - Support existing web site without React loaded.

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -15,7 +15,7 @@ function getView(
     const scrollLeft = scrollingTo || scrollable.scrollLeft;
     const items = itemContainer.children; // This will enumerate <li> inside <FilmStrip>
     const scrollCenter = scrollLeft + scrollable.offsetWidth / 2;
-    const index = best([...items], item => {
+    const index = best([].slice.call(items), item => {
       const offsetCenter = item.offsetLeft + item.offsetWidth / 2;
 
       return 1 / Math.abs(scrollCenter - offsetCenter);


### PR DESCRIPTION
## Changelog

### Fixed

- Fix [#23](https://github.com/spyip/react-film/issues/23). Fix IE11 not working with CoreJS-polyfilled `[...document.children]`, by [@compulim](https://github.com/compulim) in PR [#24](https://github.com/spyip/react-film/pull/24).
