### PR TITLE
[FIX] SSR import

### DIFF
--- a/packages/component/src/index.js
+++ b/packages/component/src/index.js
@@ -19,7 +19,7 @@ export {
   ScrollBar
 }
 
-if (document && document.head) {
+if (typeof document !== 'undefined' && document.head) {
   const meta = document.createElement('meta');
 
   meta.setAttribute('name', 'react-film');


### PR DESCRIPTION
SSR is currently broken because, when we import the package, the `index.js` that's exporting all the components is checking if `document` object exists by checking if `document` has a truly value (https://github.com/spyip/react-film/blob/master/packages/component/src/index.js#L22). This creates a runtime error `document is not defined` (see https://github.com/spyip/react-film/issues/28) because the `document` hasn't been declared and it isn't a global variable in NodeJS.
To solve this issue, `typeof` looks at the type of an undeclared variable and gives us `undefined`, since it's declared, but it does not throw an error.

This change fixes the SSR issue
