### PR TITLE
Hide flipper on edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Support right-to-left, by [@spyip](https://github.com/spyip) in PR [#32](https://github.com/spyip/react-film/pull/32).
 - Added `flipperBlurFocusOnClick` prop to `BasicFilm` and `blurFocusOnClick` prop to `Flipper` components, by [@tdurnford](https://github.com/tdurnford) in PR [#33](https://github.com/spyip/react-film/pull/33).
+- Support right-to-left on IE11, by [@spyip](https://github.com/spyip) in PR [#XXX](https://github.com/spyip/react-film/pull/XXX).
+- Hide flipper on edge items and added `autoHideFlipperOnEdge` option, by [@spyip](https://github.com/spyip) in PR [#XXX](https://github.com/spyip/react-film/pull/XXX).
 
 ### Changed
 
 - Bump peer dependency, in PR [#33](https://github.com/spyip/react-film/pull/33)
   - [react@^16.8.6](https://www.npmjs.com/package/react)
-  
+
 ### Fixed
 
 - Fix server-side rendering, by [@giulianok](https://github.com/giulianok) in PR [#29](https://github.com/spyip/react-film/pull/29).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Support right-to-left, by [@spyip](https://github.com/spyip) in PR [#32](https://github.com/spyip/react-film/pull/32).
 - Added `flipperBlurFocusOnClick` prop to `BasicFilm` and `blurFocusOnClick` prop to `Flipper` components, by [@tdurnford](https://github.com/tdurnford) in PR [#33](https://github.com/spyip/react-film/pull/33).
-- Support right-to-left on IE11, by [@spyip](https://github.com/spyip) in PR [#XXX](https://github.com/spyip/react-film/pull/XXX).
-- Hide flipper on edge items and added `autoHideFlipperOnEdge` option, by [@spyip](https://github.com/spyip) in PR [#XXX](https://github.com/spyip/react-film/pull/XXX).
+- Support right-to-left on IE11, by [@spyip](https://github.com/spyip) in PR [#34](https://github.com/spyip/react-film/pull/34).
+- Hide flipper on edge items and added `autoHideFlipperOnEdge` option, by [@spyip](https://github.com/spyip) in PR [#34](https://github.com/spyip/react-film/pull/34).
 
 ### Changed
 

--- a/packages/component/src/BasicFilm.js
+++ b/packages/component/src/BasicFilm.js
@@ -22,7 +22,7 @@ class BasicFilm extends React.Component {
     super(props);
 
     this.createHeightStyle = memoize(height => ({ height }));
-    this.createBasicStyleSet = memoize(({ autoHide }) => createBasicStyleSet({ autoHide }));
+    this.createBasicStyleSet = memoize(({ autoHide, autoHideFlipperOnEdge }) => createBasicStyleSet({ autoHide, autoHideFlipperOnEdge }));
   }
 
   render() {

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -21,7 +21,7 @@ function getView(
       rtl ?
         browser.chrome ?
           scrollLeft - (scrollable.scrollWidth - scrollable.offsetWidth)
-        : browser.edgeUWP ?
+        : browser.edgeUWP || browser.internetExplorer ?
           -scrollLeft
         :
           scrollLeft
@@ -108,7 +108,7 @@ function getScrollLeft(
       if (rtl) {
         if (browser.chrome) {
           result += scrollable.scrollWidth - scrollable.offsetWidth;
-        } else if (browser.edgeUWP) {
+        } else if (browser.edgeUWP || browser.internetExplorer) {
           result = -result;
         }
       }

--- a/packages/component/src/Flipper.js
+++ b/packages/component/src/Flipper.js
@@ -4,18 +4,20 @@ import React, { useCallback, useContext, useRef } from 'react';
 
 import Context from './Context';
 
+import * as browser from './browser';
+
 const ROOT_CSS = css({
   border: 0,
-  outline: 0,
-  touchAction: 'none'
+  outline: 0
 });
 
 export default ({ 'aria-label': ariaLabel, blurFocusOnClick, children, className, mode }) => {
-  const { scrollOneLeft, scrollOneRight } = useContext(Context);
+  const { dir, scrollBarPercentage, scrollOneLeft, scrollOneRight } = useContext(Context);
   const ref = useRef();
+  const left = mode === 'left';
 
   const handleClick = useCallback(() => {
-    mode === 'left' ? scrollOneLeft() : scrollOneRight();
+    left ? scrollOneLeft() : scrollOneRight();
     blurFocusOnClick && ref.current.blur();
   }, [blurFocusOnClick, mode, ref, scrollOneLeft, scrollOneRight]);
 
@@ -24,14 +26,34 @@ export default ({ 'aria-label': ariaLabel, blurFocusOnClick, children, className
 
     if (key === 'Enter' || key === ' ') {
       event.preventDefault();
-      mode === 'left' ? scrollOneLeft() : scrollOneRight();
+      left ? scrollOneLeft() : scrollOneRight();
     }
   }, [mode, ref, scrollOneLeft, scrollOneRight]);
 
+  let hide;
+
+  if (dir === 'rtl' && !browser.chrome) {
+    if (left) {
+      hide = scrollBarPercentage === '100%' || scrollBarPercentage === '-100%';
+    } else {
+      hide = scrollBarPercentage === '0%';
+    }
+  } else {
+    if (left) {
+      hide = scrollBarPercentage === '0%';
+    } else {
+      hide = scrollBarPercentage === '100%';
+    }
+  }
+
   return (
     <button
-      aria-label={ ariaLabel || (mode === 'left' ? 'left' : 'right') }
-      className={ classNames(ROOT_CSS + '', className) }
+      aria-label={ ariaLabel || (left ? 'left' : 'right') }
+      className={ classNames(
+        ROOT_CSS + '',
+        className,
+        { hide }
+      ) }
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       type="button"

--- a/packages/component/src/ScrollBar.js
+++ b/packages/component/src/ScrollBar.js
@@ -21,7 +21,7 @@ export default ({ className, handlerClassName }) =>
                 {
                   marginRight: `${ (parseFloat(scrollBarWidth) / 100 - 1) * parseFloat(scrollBarPercentage) }%`
                 }
-              : browser.edgeUWP ?
+              : browser.edgeUWP || browser.internetExplorer ?
                 {
                   marginRight: `${ (1 - parseFloat(scrollBarWidth) / 100) * parseFloat(scrollBarPercentage) }%`
                 }

--- a/packages/component/src/browser.js
+++ b/packages/component/src/browser.js
@@ -2,11 +2,13 @@ const { userAgent } = navigator;
 const firefox = /Firefox\//.test(userAgent);
 const edgeUWP = /Edge\//.test(userAgent);
 const chrome = !edgeUWP && /Chrome\//.test(userAgent);
-const safari = !(chrome || edgeUWP || firefox);
+const internetExplorer = /Trident\//.test(userAgent);
+const safari = !(chrome || edgeUWP || firefox || internetExplorer);
 
 export {
   chrome,
   edgeUWP,
   firefox,
-  safari,
+  internetExplorer,
+  safari
 }

--- a/packages/component/src/createBasicStyleSet.js
+++ b/packages/component/src/createBasicStyleSet.js
@@ -64,6 +64,7 @@ const createFlipperBoxCSS = ({ boxWidth, cursor, size }) => css({
   userSelect: 'none',
   top: 0,
   touchAction: 'none',
+  transitionDuration: '300ms',
   width: boxWidth,
 
   '& > div.slider': {
@@ -104,6 +105,7 @@ const createFlipperBoxCSS = ({ boxWidth, cursor, size }) => css({
 
 const createLeftFlipperCSS = options => css({
   left: 0,
+  transitionProperty: 'left',
 
   '& > div.slider': {
     left: 0
@@ -112,6 +114,7 @@ const createLeftFlipperCSS = options => css({
 
 const createRightFlipperCSS = options => css({
   right: 0,
+  transitionProperty: 'right',
 
   '& > div.slider': {
     right: 0
@@ -139,14 +142,15 @@ const createScrollBarHandlerCSS = ({ height }) => css({
 });
 
 export default function ({
-  autoHide        = true,
-  cursor          = 'pointer',
-  dotBoxSize      = DOT_BOX_SIZE,
-  dotSize         = DOT_SIZE,
-  flipperBoxWidth = FLIPPER_BOX_WIDTH,
-  flipperSize     = FLIPPER_SIZE,
-  scrollBarHeight = SCROLL_BAR_HEIGHT,
-  scrollBarMargin = SCROLL_BAR_MARGIN
+  autoHide              = true,
+  autoHideFlipperOnEdge = true,
+  cursor                = 'pointer',
+  dotBoxSize            = DOT_BOX_SIZE,
+  dotSize               = DOT_SIZE,
+  flipperBoxWidth       = FLIPPER_BOX_WIDTH,
+  flipperSize           = FLIPPER_SIZE,
+  scrollBarHeight       = SCROLL_BAR_HEIGHT,
+  scrollBarMargin       = SCROLL_BAR_MARGIN
 } = {}) {
   const styles = {
     carousel        : '',
@@ -177,7 +181,13 @@ export default function ({
       '&:focus > div.slider': {
         left: 0,
         transitionDelay: '0s'
-      }
+      },
+
+      ...(autoHideFlipperOnEdge ? {
+        '&.hide': {
+          left: -FLIPPER_BOX_WIDTH
+        }
+      } : {})
     });
 
     styles.rightFlipper = css(styles.rightFlipper, {
@@ -190,7 +200,13 @@ export default function ({
       '&:focus > div.slider': {
         right: 0,
         transitionDelay: '0s'
-      }
+      },
+
+      ...(autoHideFlipperOnEdge ? {
+        '&.hide': {
+          right: -FLIPPER_BOX_WIDTH
+        }
+      } : {})
     });
 
     styles.scrollBarBox = css(styles.scrollBarBox, {

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -3594,9 +3594,9 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
-			"version": "1.2.7",
-			"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.2.tgz",
+			"integrity": "sha512-bUTfqFWtNKWp73oNIfRkqwYZJeNT3lstzZcAkhhiuvDraRSgOH1/+F9ZklbpR4zpdKuo4cpXN8tKP7s61yjX+g=="
 		},
 		"core-js-compat": {
 			"version": "3.1.4",
@@ -5225,6 +5225,13 @@
 				"promise": "^7.1.1",
 				"setimmediate": "^1.0.5",
 				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
 		},
 		"figgy-pudding": {
@@ -10026,30 +10033,35 @@
 			}
 		},
 		"react-app-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.1.tgz",
-			"integrity": "sha512-LbVpT1NdzTdDDs7xEZdebjDrqsvKi5UyVKUQqtTYYNyC1JJYVAwNQWe4ybWvoT2V2WW9PGVO2u5Y6aVj4ER/Ow==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.4.tgz",
+			"integrity": "sha512-5Vte6ki7jpNsNCUKaboyofAhmURmCn2Y6Hu7ydJ6Iu4dct1CIGoh/1FT7gUZKAbowVX2lxVPlijvp1nKxfAl4w==",
 			"requires": {
-				"core-js": "3.0.1",
+				"core-js": "3.2.1",
 				"object-assign": "4.1.1",
-				"promise": "8.0.2",
+				"promise": "8.0.3",
 				"raf": "3.4.1",
-				"regenerator-runtime": "0.13.2",
+				"regenerator-runtime": "0.13.3",
 				"whatwg-fetch": "3.0.0"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-					"integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				},
 				"promise": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
-					"integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+					"version": "8.0.3",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+					"integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
 					"requires": {
 						"asap": "~2.0.6"
 					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 				}
 			}
 		},

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "dependencies": {
     "classnames": "^2.2.6",
+    "core-js": "^3.4.2",
     "glamor": "^2.20.40",
+    "react-app-polyfill": "^1.0.4",
     "react-film": "0.0.0-0",
     "react-scripts": "^3.0.1"
   },

--- a/packages/playground/src/index.js
+++ b/packages/playground/src/index.js
@@ -1,3 +1,7 @@
+import 'core-js/features/array/fill';
+import 'core-js/features/math/sign';
+import 'react-app-polyfill/ie11';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';


### PR DESCRIPTION
- Support right-to-left on IE11, by [@spyip](https://github.com/spyip) in PR [#34](https://github.com/spyip/react-film/pull/34).

- Hide flipper on edge items and added `autoHideFlipperOnEdge` option, by [@spyip](https://github.com/spyip) in PR [#34](https://github.com/spyip/react-film/pull/34).