### PR TITLE
Use flipper box for hide on edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed [#37](https://github.com/spyip/react-film/pull/37), hiding overflowing button when at edge, by [@compulim](https://github.com/compulim) in PR [#39](https://github.com/spyip/react-film/pull/39).
+
 ## [2.0.1] - 2020-01-15
 
 ### Fixed

--- a/packages/component/src/createBasicStyleSet.js
+++ b/packages/component/src/createBasicStyleSet.js
@@ -177,39 +177,27 @@ export default function createBasicStyleSet({
     styles.leftFlipper = css(styles.leftFlipper, {
       '& > div.slider': {
         ...flipperOverrides,
-        left: -50,
+        left: (FLIPPER_BOX_WIDTH + FLIPPER_SIZE) / -2,
         transitionProperty: 'left'
       },
 
-      '&:focus > div.slider': {
+      [`&:focus${ autoHideFlipperOnEdge ? ':not(.hide)' : '' } > div.slider`]: {
         left: 0,
         transitionDelay: '0s'
-      },
-
-      ...(autoHideFlipperOnEdge ? {
-        '&.hide': {
-          left: -FLIPPER_BOX_WIDTH
-        }
-      } : {})
+      }
     });
 
     styles.rightFlipper = css(styles.rightFlipper, {
       '& > div.slider': {
         ...flipperOverrides,
-        right: -50,
+        right: (FLIPPER_BOX_WIDTH + FLIPPER_SIZE) / -2,
         transitionProperty: 'right'
       },
 
-      '&:focus > div.slider': {
+      [`&:focus${ autoHideFlipperOnEdge ? ':not(.hide)' : '' } > div.slider`]: {
         right: 0,
         transitionDelay: '0s'
-      },
-
-      ...(autoHideFlipperOnEdge ? {
-        '&.hide': {
-          right: -FLIPPER_BOX_WIDTH
-        }
-      } : {})
+      }
     });
 
     styles.scrollBarBox = css(styles.scrollBarBox, {
@@ -231,11 +219,11 @@ export default function createBasicStyleSet({
           bottom: 0
         },
 
-        [`& .${ styles.leftFlipper + '' } > div.slider`]: {
+        [`& .${ styles.leftFlipper + '' }${ autoHideFlipperOnEdge ? ':not(.hide)' : '' } > div.slider`]: {
           left: 0
         },
 
-        [`& .${ styles.rightFlipper + '' } > div.slider`]: {
+        [`& .${ styles.rightFlipper + '' }${ autoHideFlipperOnEdge ? ':not(.hide)' : '' } > div.slider`]: {
           right: 0
         }
       }


### PR DESCRIPTION
> Fix #37.

## Changelog

### Fixed

- Fixed [#37](https://github.com/spyip/react-film/pull/37), hiding overflowing button when at edge, by [@compulim](https://github.com/compulim) in PR [#39](https://github.com/spyip/react-film/pull/39).
