### PR TITLE
RTL in Chrome should follow Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed [#75](https://github.com/spyip/react-film/issues/75). Flippers, dots, and scroll bar should work in right-to-left (RTL) correctly in Chrome 85 and beyond, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/spyip/react-film/pull/XXX)
+- Fixed [#75](https://github.com/spyip/react-film/issues/75). Flippers, dots, and scroll bar should work in right-to-left (RTL) correctly in Chrome 85 and beyond, by [@compulim](https://github.com/compulim), in PR [#86](https://github.com/spyip/react-film/pull/86)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed [#75](https://github.com/spyip/react-film/issues/75). Flippers, dots, and scroll bar should work in right-to-left (RTL) correctly in Chrome 85 and beyond, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/spyip/react-film/pull/XXX)
+
 ### Changes
 
 - Moved from [`webpack`](https://webpack.js.org/) to [`esbuild@0.12.1`](https://esbuild.github.io/), by [@compulim](https://github.com/compulim), in PR [#85](https://github.com/spyip/react-film/pull/85)

--- a/packages/component/src/Flipper.js
+++ b/packages/component/src/Flipper.js
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useCallback, useRef } from 'react';
 
-import * as browser from './browser';
 import useDir from './hooks/useDir';
 import useScrollBarPercentage from './hooks/useScrollBarPercentage';
 import useScrollOneLeft from './hooks/useScrollOneLeft';
@@ -35,7 +34,7 @@ const Flipper = ({ 'aria-label': ariaLabel, blurFocusOnClick, children, mode }) 
 
   let hide;
 
-  if (dir === 'rtl' && !browser.chrome) {
+  if (dir === 'rtl') {
     if (left) {
       hide = scrollBarPercentage === '100%' || scrollBarPercentage === '-100%';
     } else {

--- a/packages/component/src/ScrollBar.js
+++ b/packages/component/src/ScrollBar.js
@@ -18,16 +18,12 @@ const ScrollBar = () => {
         className="react-film__scroll-bar__handle"
         style={{
           ...(dir === 'rtl'
-            ? browser.firefox || browser.safari
-              ? {
-                  marginRight: `${(parseFloat(scrollBarWidth) / 100 - 1) * parseFloat(scrollBarPercentage)}%`
-                }
-              : browser.edgeUWP || browser.internetExplorer
+            ? browser.edgeUWP || browser.internetExplorer
               ? {
                   marginRight: `${(1 - parseFloat(scrollBarWidth) / 100) * parseFloat(scrollBarPercentage)}%`
                 }
               : {
-                  marginRight: `${(1 - parseFloat(scrollBarWidth) / 100) * (100 - parseFloat(scrollBarPercentage))}%`
+                  marginRight: `${(parseFloat(scrollBarWidth) / 100 - 1) * parseFloat(scrollBarPercentage)}%`
                 }
             : {
                 marginLeft: `${(1 - parseFloat(scrollBarWidth) / 100) * parseFloat(scrollBarPercentage)}%`

--- a/packages/component/src/computeScrollLeft.js
+++ b/packages/component/src/computeScrollLeft.js
@@ -23,13 +23,10 @@ export default function computeScrollLeft(dir, scrollable, itemContainer, index)
         result = Math.min(result, scrollable.scrollWidth - scrollable.offsetWidth);
       }
 
-      if (rtl) {
-        if (browser.chrome) {
-          result += scrollable.scrollWidth - scrollable.offsetWidth;
-        } else if (browser.edgeUWP || browser.internetExplorer) {
-          result = -result;
-        }
+      if (rtl && (browser.edgeUWP || browser.internetExplorer)) {
+        result = -result;
       }
+
       return result;
     }
   }

--- a/packages/component/src/getView.js
+++ b/packages/component/src/getView.js
@@ -8,13 +8,7 @@ export default function getView(dir, scrollable, itemContainer, scrollingTo) {
 
   if (itemContainer && scrollable) {
     const scrollLeft = scrollingTo || scrollable.scrollLeft;
-    const trueScrollLeft = rtl
-      ? browser.chrome
-        ? scrollLeft - (scrollable.scrollWidth - scrollable.offsetWidth)
-        : browser.edgeUWP || browser.internetExplorer
-        ? -scrollLeft
-        : scrollLeft
-      : scrollLeft;
+    const trueScrollLeft = rtl && (browser.edgeUWP || browser.internetExplorer) ? -scrollLeft : scrollLeft;
     const items = itemContainer.children; // This will enumerate <li> inside <FilmStrip>
     const scrollCenter = trueScrollLeft + scrollable.offsetWidth / 2;
     const index = best([].slice.call(items), item => {


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed [#75](https://github.com/spyip/react-film/issues/75). Flippers, dots, and scroll bar should work in right-to-left (RTL) correctly in Chrome 85 and beyond, by [@compulim](https://github.com/compulim), in PR [#86](https://github.com/spyip/react-film/pull/86)

## Specific changes

> Please list each individual specific change in this pull request.

- Updated flipper, scroll bar, and other view computation logic for Chrome to follow Firefox

The change was because Chromium 85 fixed [an issue](https://www.chromestatus.com/feature/5759578031521792) on `scrollLeft`. `react-film` should no longer applies the workaround.