### PR TITLE
feat: add stylesRoot property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `leftFlipperAriaLabel` and `rightFlipperAriaLabel` for customizing the `aria-label` attribute for flipper buttons, by [@compulim](https://github.com/compulim), in PR [#98](https://github.com/spyip/react-film/pull/98)
+- Added `stylesRoot` property which allows to specify a container node component styles will be placed into, by [@OEvgeny](https://github.com/OEvgeny) in PR [#137](https://github.com/spyip/react-film/pull/102)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `leftFlipperAriaLabel` and `rightFlipperAriaLabel` for customizing the `aria-label` attribute for flipper buttons, by [@compulim](https://github.com/compulim), in PR [#98](https://github.com/spyip/react-film/pull/98)
-- Added `stylesRoot` property which allows to specify a container node component styles will be placed into, by [@OEvgeny](https://github.com/OEvgeny) in PR [#137](https://github.com/spyip/react-film/pull/102)
+- Added `stylesRoot` property which allows to specify a container node component styles will be placed into, by [@OEvgeny](https://github.com/OEvgeny) in PR [#102](https://github.com/spyip/react-film/pull/102)
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You can control `<BasicFilm>` using props listed below.
 | `styleSet.rightFlipper`     | [`'css-*'`](https://github.com/threepointone/glamor/blob/master/docs/howto.md#apply-a-style-to-an-element) | Class name for right flipper                                                                                                               |
 | `styleSet.scrollBarBox`     | [`'css-*'`](https://github.com/threepointone/glamor/blob/master/docs/howto.md#apply-a-style-to-an-element) | Class name for scroll bar container                                                                                                        |
 | `styleSet.scrollBarHandler` | [`'css-*'`](https://github.com/threepointone/glamor/blob/master/docs/howto.md#apply-a-style-to-an-element) | Class name for scroll bar handler                                                                                                          |
+| `stylesRoot`                |  `undefined`                                                                                               | Set the container node for component styles to be placed into. When set to `undefined`, will use `document.head`                           |
 
 ## Basic style set
 

--- a/packages/bundle/src/index.js
+++ b/packages/bundle/src/index.js
@@ -22,4 +22,4 @@ function retrofit(element, props) {
   );
 }
 
-window.ReactFilm = { retrofit };
+window.ReactFilm = { retrofit, BasicFilm };

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -170,8 +170,6 @@ const Composer = ({ children, dir, height, nonce, numItems, styleOptions, styleS
     scrollLeftRef.current,
     handleScrollToEnd
   );
-  // eslint-disable-next-line no-console
-  console.log('rerendered', scrollLeftRef.current, scrollableCallbackRefWithSubscribe.current);
 
   useEffect(
     () =>

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -1,11 +1,9 @@
-import createEmotion from '@emotion/css/create-instance';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import AutoCenter from './AutoCenter';
 import computeScrollLeft from './computeScrollLeft';
 import createBasicStyleSet from './createBasicStyleSet';
-import createCSSKey from './util/createCSSKey';
 import FunctionContext from './FunctionContext';
 import getView from './getView';
 import InternalContext from './InternalContext';
@@ -14,11 +12,9 @@ import patchStyleOptions from './patchStyleOptions';
 import PropsContext from './PropsContext';
 import useAnimateScrollLeft from './hooks/internal/useAnimateScrollLeft';
 import useCallbackRefWithSubscribe from './hooks/internal/useCallbackRefWithSubscribe';
+import useEmotion from './hooks/internal/useEmotion';
 import useObserveScrollLeft from './hooks/internal/useObserveScrollLeft';
 import ViewContext from './ViewContext';
-
-// We pool the emotion, so we don't create a new set of <style> for every component and reuse as much as we could.
-const emotionPool = {};
 
 const Composer = ({ children, dir, height, nonce, numItems, styleOptions, styleSet }) => {
   dir = dir === 'ltr' || dir === 'rtl' ? dir : undefined;
@@ -29,12 +25,11 @@ const Composer = ({ children, dir, height, nonce, numItems, styleOptions, styleS
     [patchedStyleOptions, styleSet]
   );
 
-  const styleSetClassNames = useMemo(() => {
-    const emotion =
-      emotionPool[nonce] || (emotionPool[nonce] = createEmotion({ key: `react-film--css-${createCSSKey()}`, nonce }));
-
-    return Object.fromEntries(Object.entries(patchedStyleSet).map(([name, style]) => [name, emotion.css(style) + '']));
-  }, [nonce, patchedStyleSet]);
+  const emotion = useEmotion(nonce, styleOptions.stylesRoot);
+  const styleSetClassNames = useMemo(
+    () => Object.fromEntries(Object.entries(patchedStyleSet).map(([name, style]) => [name, emotion.css(style) + ''])),
+    [emotion, patchedStyleSet]
+  );
 
   const [_, forceRender] = useState();
   const itemContainerCallbackRefWithSubscribe = useCallbackRefWithSubscribe();
@@ -175,6 +170,8 @@ const Composer = ({ children, dir, height, nonce, numItems, styleOptions, styleS
     scrollLeftRef.current,
     handleScrollToEnd
   );
+  // eslint-disable-next-line no-console
+  console.log('rerendered', scrollLeftRef.current, scrollableCallbackRefWithSubscribe.current);
 
   useEffect(
     () =>

--- a/packages/component/src/ReactFilm.js
+++ b/packages/component/src/ReactFilm.js
@@ -21,7 +21,8 @@ const ReactFilm = ({
   showDots,
   showFlipper,
   showScrollBar,
-  styleSet
+  styleSet,
+  stylesRoot
 }) => {
   const styleOptions = useMemo(
     () => ({
@@ -29,28 +30,30 @@ const ReactFilm = ({
       autoHide,
       autoHideFlipperOnEdge,
       dir,
+      flipperBlurFocusOnClick,
       leftFlipperAriaLabel,
       leftFlipperText,
-      flipperBlurFocusOnClick,
       rightFlipperAriaLabel,
       rightFlipperText,
       showDots,
       showFlipper,
-      showScrollBar
+      showScrollBar,
+      stylesRoot
     }),
     [
       autoCenter,
       autoHide,
       autoHideFlipperOnEdge,
       dir,
+      flipperBlurFocusOnClick,
       leftFlipperAriaLabel,
       leftFlipperText,
-      flipperBlurFocusOnClick,
       rightFlipperAriaLabel,
       rightFlipperText,
       showDots,
       showFlipper,
-      showScrollBar
+      showScrollBar,
+      stylesRoot
     ]
   );
 
@@ -85,7 +88,8 @@ ReactFilm.defaultProps = {
   showDots: undefined,
   showFlipper: undefined,
   showScrollBar: undefined,
-  styleSet: undefined
+  styleSet: undefined,
+  stylesRoot: undefined
 };
 
 ReactFilm.propTypes = {
@@ -106,7 +110,8 @@ ReactFilm.propTypes = {
   showDots: PropTypes.bool,
   showFlipper: PropTypes.bool,
   showScrollBar: PropTypes.bool,
-  styleSet: PropTypes.any
+  styleSet: PropTypes.any,
+  stylesRoot: PropTypes.any
 };
 
 export default ReactFilm;

--- a/packages/component/src/hooks/internal/useEmotion.js
+++ b/packages/component/src/hooks/internal/useEmotion.js
@@ -18,21 +18,19 @@ export default function useEmotion(nonce, container) {
   }, [container, nonce]);
 
   useEffect(
-    () =>
-      emotion?.sheet &&
-      (() => {
-        const index = sharedEmotionInstances.lastIndexOf(emotion);
+    () => () => {
+      const index = sharedEmotionInstances.lastIndexOf(emotion);
 
-        // Reduce ref count for the specific emotion instance.
-        ~index && sharedEmotionInstances.splice(index, 1);
+      // Reduce ref count for the specific emotion instance.
+      ~index && sharedEmotionInstances.splice(index, 1);
 
-        if (!sharedEmotionInstances.includes(emotion)) {
-          // No more hooks use this emotion object, we can clean up the container for stuff we added.
-          for (const child of emotion.sheet.tags) {
-            child.remove();
-          }
+      if (!sharedEmotionInstances.includes(emotion) && emotion.sheet?.tags) {
+        // No more hooks use this emotion object, we can clean up the container for stuff we added.
+        for (const child of emotion.sheet.tags) {
+          child.remove();
         }
-      }),
+      }
+    },
     [emotion]
   );
 

--- a/packages/component/src/hooks/internal/useEmotion.js
+++ b/packages/component/src/hooks/internal/useEmotion.js
@@ -1,0 +1,40 @@
+import createEmotion from '@emotion/css/create-instance';
+import { useEffect, useMemo } from 'react';
+
+import createCSSKey from '../../util/createCSSKey';
+
+const sharedEmotionInstances = [];
+
+export default function useEmotion(nonce, container) {
+  const emotion = useMemo(() => {
+    const sharedEmotion = sharedEmotionInstances.find(
+      ({ sheet }) => sheet.nonce === nonce && sheet.container === container
+    );
+    const emotion = sharedEmotion ?? createEmotion({ container, key: `react-film--css-${createCSSKey()}`, nonce });
+
+    sharedEmotionInstances.push(emotion);
+
+    return emotion;
+  }, [container, nonce]);
+
+  useEffect(
+    () =>
+      emotion?.sheet &&
+      (() => {
+        const index = sharedEmotionInstances.lastIndexOf(emotion);
+
+        // Reduce ref count for the specific emotion instance.
+        ~index && sharedEmotionInstances.splice(index, 1);
+
+        if (!sharedEmotionInstances.includes(emotion)) {
+          // No more hooks use this emotion object, we can clean up the container for stuff we added.
+          for (const child of emotion.sheet.tags) {
+            child.remove();
+          }
+        }
+      }),
+    [emotion]
+  );
+
+  return emotion;
+}

--- a/samples/index-with-custom-element.html
+++ b/samples/index-with-custom-element.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>React Film</title>
+    <script crossorigin="anonymous" src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="/react-film/react-film.development.js"></script>
+  </head>
+  <body>
+    <react-film>
+    </react-film>
+    <script type="text/babel">
+      const {
+        React,
+        ReactDOM: { render },
+        ReactFilm: { BasicFilm }
+      } = window;
+      !(function () {
+        'use strict';
+
+        class ReactFilmlement extends HTMLElement {
+          constructor() {
+            super();
+            this.attachShadow({ mode: 'open' });
+          }
+
+          connectedCallback() {
+            const App = () => (
+              <BasicFilm height={316} stylesRoot={this.shadowRoot}>
+                <img alt="Cat 01" src="image/01.jpg" />
+                <img alt="Cat 02" src="image/02.jpg" />
+                <img alt="Cat 03" src="image/03.jpg" />
+                <img alt="Cat 04" src="image/04.jpg" />
+                <img alt="Cat 05" src="image/05.jpg" />
+                <img alt="Cat 06" src="image/06.jpg" />
+                <img alt="Cat 07" src="image/07.jpg" />
+                <img alt="Cat 08" src="image/08.jpg" />
+                <img alt="Cat 09" src="image/09.jpg" />
+                <img alt="Cat 10" src="image/10.jpg" />
+                <img alt="Cat 11" src="image/11.jpg" />
+              </BasicFilm>
+            )
+
+            render(
+              <App />,
+              this.shadowRoot
+            );
+          }
+        }
+
+        customElements.define('react-film', ReactFilmlement);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Changelog

- Added `stylesRoot` property which allows to specify a container node component styles will be placed into, by [@OEvgeny](https://github.com/OEvgeny) in PR [#102](https://github.com/spyip/react-film/pull/102)


## Specific changes

- Reworked emotion caching: added `useEmotion` hook
- Added `styleOptions.stylesRoot` property
- Exposed `BasicFilm` to window
- Updated docs
- Added sample