### PR TITLE
Enable JSX runtime for script tag sample

### DIFF
--- a/packages/pages/public/script-tag/bundle.html
+++ b/packages/pages/public/script-tag/bundle.html
@@ -2,14 +2,27 @@
 <html lang="en">
   <head>
     <link href="../common.css" rel="stylesheet" type="text/css" />
-    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="../static/react-film/umd/react-film.production.min.js"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@18",
+          "react-dom": "https://esm.sh/react-dom@18"
+        }
+      }
+    </script>
+    <script type="module">
+      import React from 'react';
+      import ReactDOM from 'react-dom';
+
+      window.React = React;
+      window.ReactDOM = ReactDOM;
+    </script>
+    <script defer src="../static/react-film/umd/react-film.production.min.js"></script>
     <script src="https://esm.sh/tsx" type="module"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script async id="code" type="text/babel">
+    <script id="code" type="text/babel">
       const { ReactFilm } = window.ReactFilm;
 
       window.ReactDOM.render(


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

(No changelog for non-production-related changes.)

## Specific changes

> Please list each individual specific change in this pull request.

- Using `esm.sh` to load React so it enable JSX runtime